### PR TITLE
Fix libxcrypt dependency for apt

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.8
 Build-Depends:
  debhelper (>=9), libtool, libcurl4-openssl-dev, 
  libjansson-dev, libjwt-dev, libsds-dev, libsodium-dev,
- libssl-dev, libxcrypt-dev
+ libssl-dev, libcrypt-dev
 Vcs-Git: https://github.com/aad-for-linux/libnss_aad.git
 Vcs-Browser: https://github.com/aad-for-linux/libnss_aad
 Homepage: https://github.com/aad-for-linux/libnss_aad

--- a/libnss_aad.c
+++ b/libnss_aad.c
@@ -16,7 +16,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <xcrypt.h>
 
 #define CONF_FILE "/etc/libnss-aad.conf"
 #define MAX_PASSWD_LENGTH 32


### PR DESCRIPTION
The libxcrypt package is now the default libcrypt implementation, which means that we should now use libcrypt-dev instead of libxcrypt-dev

Bug: https://github.com/aad-for-linux/libnss-aad/issues/9